### PR TITLE
Set-PfTitle should throw an error if the secret key is incorrect.

### DIFF
--- a/PfMultiplayerCmdlets/PFBaseCmdlet.cs
+++ b/PfMultiplayerCmdlets/PFBaseCmdlet.cs
@@ -43,14 +43,7 @@
 
         protected static T CallPlayFabApi<T>(Func<Task<PlayFabResult<T>>> apiCall) where T : PlayFabResultCommon
         {
-            try
-            {
-                PFTokenUtility.Instance.GetPFTitleEntityToken();
-            }
-            catch (Exception e)
-            {
-                throw new Exception(e.ToString());
-            }
+            PFTokenUtility.Instance.GetPFTitleEntityToken();
 
             PlayFabResult<T> result = apiCall().Result;
             if (result.Error != null)

--- a/PfMultiplayerCmdlets/PFTokenUtility.cs
+++ b/PfMultiplayerCmdlets/PFTokenUtility.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Reflection;
     using System.Threading.Tasks;
+    using Newtonsoft.Json;
     using PlayFab;
     using PlayFab.AuthenticationModels;
     using BindingFlags = System.Reflection.BindingFlags;
@@ -43,19 +44,22 @@
                 PlayFabSettings.staticSettings.DeveloperSecretKey = _secretKey;
 
                 // The SDK sets the entity token as part of response evaluation.
-                PlayFabAuthenticationAPI.GetEntityTokenAsync(request).Wait();
+                PlayFabResult<GetEntityTokenResponse> response = PlayFabAuthenticationAPI.GetEntityTokenAsync(request).Result;
+                if (response.Error != null)
+                {
+                    throw new Exception($"Error occurred while calling the api. {JsonConvert.SerializeObject(response.Error)}.");
+                }
+
                 _tokenRefreshTime = DateTime.UtcNow.AddHours(TokenRefreshIntervalInHours);
             }
         }
 
         public void SetTitleSecretKey(string titleId, string secret)
         {
-            if (!string.Equals(TitleId, titleId, StringComparison.OrdinalIgnoreCase))
-            {
-                TitleId = titleId;
-                _secretKey = secret;
-                _tokenRefreshTime = DateTime.MinValue;
-            }
+            TitleId = titleId;
+            _secretKey = secret;
+            _tokenRefreshTime = DateTime.MinValue;
+            
         }
     }
 }

--- a/PfMultiplayerCmdlets/PlayFabMultiplayer.psd1
+++ b/PfMultiplayerCmdlets/PlayFabMultiplayer.psd1
@@ -12,7 +12,7 @@
  RootModule = 'PFMultiplayerCmdlets.dll'
 
 # Version number of this module.
-ModuleVersion = '0.935'
+ModuleVersion = '0.936'
 
 # ID used to uniquely identify this module
 GUID = '4983f215-13a8-4e0a-a26c-82278df23074'


### PR DESCRIPTION
Set-PfTitle should throw an error if the secret key is incorrect. Right now, it silently fails and later cmdlets give an unhelpful error.